### PR TITLE
Cleaning up CoreCommonEvent

### DIFF
--- a/CoreCommonEvent.cs
+++ b/CoreCommonEvent.cs
@@ -1,98 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Crystal_Editor
+﻿namespace Crystal_Editor
 {
     public class CoreCommonEvent
     {
-						
-		public byte[] data_array; //This starts the array.
-		public string SaveLoad = "Empty"; //This just defines this string to be used later. It lets
-		public string TextName = "Dummy";
-		private int Start = 0; //Leagth from start of file to the byte where the first row / data starts. The first byte is #0, most hex editors count byte0 so they should be accurate...probably.
-		private int Row = 0; //Leagth of a row of data. The first byte is #1 not #0, so if a row starts at column 0 and is 29 long, then input 30.  This is used in every load and save of data to the array.
-		public int Column = 0;
-		public CoreCommonEvent(int start, int row) { Start = start; Row = row; }
-		
-
-		public void MoveData(TreeView tree, Control.ControlCollection control)
+        public enum MoveRequest
         {
-            if (this.SaveLoad == "Load")
-			{
-				SetText(control, TextName, this.data_array[Start + (tree.SelectedNode.Index * Row) + Column].ToString("D") );
-			}
-
-            if (this.SaveLoad == "Save")
-			{ 
-				Byte.TryParse(GetText( control, TextName), out byte value8); 
-				{ 
-					TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + Column); 
-				} 
-			}
+            Save,
+            Load
         }
 
-		public void MoveDataReverse4(TreeView tree, Control.ControlCollection control)
-		{
-			if (this.SaveLoad == "Load")
-			{
-				Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + Column, 4);
-				SetText(control, TextName, this.data_array[Start + (tree.SelectedNode.Index * Row) + Column].ToString("D"));
-				Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + Column, 4);
-			}
+        public byte[] data_array; //This starts the array.
+        private int Start = 0; //Leagth from start of file to the byte where the first row / data starts. The first byte is #0, most hex editors count byte0 so they should be accurate...probably.
+        private int Row = 0; //Leagth of a row of data. The first byte is #1 not #0, so if a row starts at column 0 and is 29 long, then input 30.  This is used in every load and save of data to the array.
 
-			if (this.SaveLoad == "Save")
-			{
-				Byte.TryParse(GetText(control, TextName), out byte value8);
-				{
-					TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + Column);
-					Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + Column, 4);
-				}
-			}
-		}
+        public CoreCommonEvent(string fileLocation, int start, int row)
+        {
+            data_array = File.ReadAllBytes(fileLocation);
+            Start = start;
+            Row = row;
+        }
 
-		public void MoveDataReverse2(TreeView tree, Control.ControlCollection control)
-		{
-			if (this.SaveLoad == "Load")
-			{
-				Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + Column, 2);
-				SetText(control, TextName, this.data_array[Start + (tree.SelectedNode.Index * Row) + Column].ToString("D"));
-				Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + Column, 2);
-			}
+        public void MoveData(TreeView tree, Control.ControlCollection control, string textName, int column, MoveRequest requestType)
+        {
+            switch (requestType)
+            {
+                case MoveRequest.Save:
+                    Byte.TryParse(GetText(control, textName), out byte value8);
+                    TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + column);
+                    break;
+                case MoveRequest.Load:
+                    SetText(control, textName, this.data_array[Start + (tree.SelectedNode.Index * Row) + column].ToString("D"));
+                    break;
+            }
+        }
 
-			if (this.SaveLoad == "Save")
-			{
-				Byte.TryParse(GetText(control, TextName), out byte value8);
-				{
-					TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + Column);
-					Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + Column, 2);
-				}
-			}
-		}
+        public void MoveDataReverse(TreeView tree, Control.ControlCollection control, string textName, int column, MoveRequest requestType, int length)
+        {
+            switch (requestType)
+            {
+                case MoveRequest.Save:
+                    Byte.TryParse(GetText(control, textName), out byte value8);
+                    TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + column);
+                    Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + column, length);
+                    break;
+                case MoveRequest.Load:
+                    Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + column, length);
+                    SetText(control, textName, this.data_array[Start + (tree.SelectedNode.Index * Row) + column].ToString("D"));
+                    Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + column, length);
+                    break;
+            }
+        }
 
+        //The following must be here, it was made by some guy on stackoverflow,  then modififed by starkelp in twitch chat :)
+        //It takes things named TitleForm[X] where X is a variable with a string, and lets you use the string as a textboxes name with .text at the end.
+        //This lets you use a variable in place of a textbox.text property, so you can refer to them indirectly.
+        public string GetText(Control.ControlCollection control, string name, string? defaultText = null) //this Form form, string name, string defaultText = null
+        {
+            return control.ContainsKey(name) ?
+                control[name].Text :
+                (defaultText ?? string.Empty);
+        }
 
-
-		//The following must be here, it was made by some guy on stackoverflow,  then modififed by starkelp in twitch chat :)
-		//It takes things named TitleForm[X] where X is a variable with a string, and lets you use the string as a textboxes name with .text at the end.
-		//This lets you use a variable in place of a textbox.text property, so you can refer to them indirectly.
-		public string GetText(Control.ControlCollection control, string name, string defaultText = null) //this Form form, string name, string defaultText = null
-		{
-			return control.ContainsKey(name) ?
-				control[name].Text :
-				(defaultText ?? string.Empty);
-		}
-
-		public void SetText(Control.ControlCollection control, string name, string text) //this Form form, string name, string text
-		{
-			if (control.ContainsKey(name))
-			{
-				var control2 = control[name];
-				control2.Text = text;
-			}
-		}
-
-	
-	}
+        public void SetText(Control.ControlCollection control, string name, string text) //this Form form, string name, string text
+        {
+            if (control.ContainsKey(name))
+            {
+                var control2 = control[name];
+                control2.Text = text;
+            }
+        }
+    }
 }

--- a/Template/Enemy Template.cs
+++ b/Template/Enemy Template.cs
@@ -1,38 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
-using System.IO;
-using System.Diagnostics;
-using Microsoft.Win32;
-using Microsoft.WindowsAPICodePack.Dialogs;
-
-namespace Crystal_Editor
+﻿namespace Crystal_Editor
 {
-
-    
-
     public partial class EnemyTemplateForm : Form
     {
-        private CoreCommonEvent events = new CoreCommonEvent(start: 37,row: 38);
+        private CoreCommonEvent events;
         //int RevNum = 0; //Used in Array Reverse to simplify looking at it and reduce input mistakes.
 
-
-
-        
         public EnemyTemplateForm()
         {
             InitializeComponent();
-            string FileLocation = Properties.Settings.Default.SpotTemplateFolder + "\\Template Editor\\EnemyTemplate"; //Sets a string called File Location to the location of where the game file were gonna mod / edit is.  Used to be Data_Location
-            int Data_Length = (int)(new FileInfo(FileLocation).Length);   //Sets the entire file as the leagth of the array.   Used to be EnemyData_Leagth
-            events.data_array = File.ReadAllBytes(FileLocation);  //loads an array with whatever is in the path
-            
+            events = new CoreCommonEvent(fileLocation: Properties.Settings.Default.SpotTemplateFolder + "\\Template Editor\\EnemyTemplate", start: 37, row: 38);
 
             Tree.Nodes.Add("Goblin");
             Tree.Nodes.Add("Slime");
@@ -57,42 +33,35 @@ namespace Crystal_Editor
 
         private void Tree_AfterSelect(object sender, TreeViewEventArgs e)
         {
-            events.SaveLoad = "Load";
-            Editor();
+            Editor(CoreCommonEvent.MoveRequest.Load);
         }
         private void Button6_Click(object sender, EventArgs e) //Load Button
         {
-            events.SaveLoad = "Load";
-            Editor();
+            Editor(CoreCommonEvent.MoveRequest.Load);
         }
         private void Button5_Click(object sender, EventArgs e) //Save Button
         {
-            events.SaveLoad = "Save";
-            Editor();
+            Editor(CoreCommonEvent.MoveRequest.Save);
         }
-               
 
 
-        public void Editor()
+
+        public void Editor(CoreCommonEvent.MoveRequest requestType)
         {
             //Numbers start from Left and read to right Right (normal?) Endianese.
             //Final number is the column the data is from / how many bytes into a row the data is from. The first byte is byte 1 not byte 0.
 
-            events.TextName = "richTextBoxID"; events.Column = 1; events.MoveData(Tree, Controls); //1 Byte
-            events.TextName = "richTextBoxStr"; events.Column = 17; events.MoveData(Tree, Controls); //4 Byte
-            events.TextName = "richTextBoxMag"; events.Column = 21; events.MoveData(Tree, Controls); //4 Byte
-            events.TextName = "richTextBoxDef"; events.Column = 25; events.MoveData(Tree, Controls); //2 Byte
-            events.TextName = "richTextBoxRes"; events.Column = 27; events.MoveData(Tree, Controls); //2 Byte
-            events.TextName = "richTextBoxTP"; events.Column = 15; events.MoveData(Tree, Controls); //1 Byte
+            events.MoveData(Tree, Controls, textName: "richTextBoxID", column: 1, requestType); //1 Byte
+            events.MoveData(Tree, Controls, textName: "richTextBoxStr", column: 17, requestType); //4 Byte
+            events.MoveData(Tree, Controls, textName: "richTextBoxMag", column: 21, requestType); //4 Byte
+            events.MoveData(Tree, Controls, textName: "richTextBoxDef", column: 25, requestType); //2 Byte
+            events.MoveData(Tree, Controls, textName: "richTextBoxRes", column: 27, requestType); //2 Byte
+            events.MoveData(Tree, Controls, textName: "richTextBoxTP", column: 15, requestType); //1 Byte
 
-            events.TextName = "richTextBoxRev4"; events.Column = 2; events.MoveDataReverse4(Tree, Controls); //4R Byte
-            events.TextName = "richTextBoxRev2"; events.Column = 10; events.MoveDataReverse2(Tree, Controls); //2R Byte
+            events.MoveDataReverse(Tree, Controls, textName: "richTextBoxRev4", column: 2, requestType, length: 4); //4R Byte
+            events.MoveDataReverse(Tree, Controls, textName: "richTextBoxRev2", column: 10, requestType, length: 2); //2R Byte
 
         }
-
-
-        
-
 
         /*
 
@@ -119,14 +88,10 @@ namespace Crystal_Editor
 
         */
 
-
         private void Tree_BeforeSelect(object sender, TreeViewCancelEventArgs e)
         {
 
         }
-
-        
-        
 
         private void EnemyTemplateForm_Load(object sender, EventArgs e)
         {


### PR DESCRIPTION
Fixed a number of unneeded variables, fixed spacing, and shortened a number of functions.

Unable to test this as I did not have access to the file you were using on stream, let me know if something isn't working. The intent here is to make it as self sufficient as possible, without needing extra variables set up everywhere, and minimizing the number of extra functions.