### PR TITLE
Further Simplification

### DIFF
--- a/CoreCommonEvent.cs
+++ b/CoreCommonEvent.cs
@@ -11,41 +11,45 @@
         public byte[] data_array; //This starts the array.
         private int Start = 0; //Leagth from start of file to the byte where the first row / data starts. The first byte is #0, most hex editors count byte0 so they should be accurate...probably.
         private int Row = 0; //Leagth of a row of data. The first byte is #1 not #0, so if a row starts at column 0 and is 29 long, then input 30.  This is used in every load and save of data to the array.
+        private TreeView Tree;
+        private Control.ControlCollection Controls;
 
-        public CoreCommonEvent(string fileLocation, int start, int row)
+        public CoreCommonEvent(string fileLocation, int start, int row, TreeView tree, Control.ControlCollection controls)
         {
             data_array = File.ReadAllBytes(fileLocation);
             Start = start;
             Row = row;
+            Tree = tree;
+            Controls = controls;
         }
 
-        public void MoveData(TreeView tree, Control.ControlCollection control, string textName, int column, MoveRequest requestType)
+        public void MoveData(string textName, int column, MoveRequest requestType)
         {
             switch (requestType)
             {
                 case MoveRequest.Save:
-                    Byte.TryParse(GetText(control, textName), out byte value8);
-                    TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + column);
+                    Byte.TryParse(GetText(textName), out byte value8);
+                    TitleForm.ByteWriter(value8, data_array, Start + (Tree.SelectedNode.Index * Row) + column);
                     break;
                 case MoveRequest.Load:
-                    SetText(control, textName, this.data_array[Start + (tree.SelectedNode.Index * Row) + column].ToString("D"));
+                    SetText(textName, this.data_array[Start + (Tree.SelectedNode.Index * Row) + column].ToString("D"));
                     break;
             }
         }
 
-        public void MoveDataReverse(TreeView tree, Control.ControlCollection control, string textName, int column, MoveRequest requestType, int length)
+        public void MoveDataReverse(string textName, int column, MoveRequest requestType, int length)
         {
             switch (requestType)
             {
                 case MoveRequest.Save:
-                    Byte.TryParse(GetText(control, textName), out byte value8);
-                    TitleForm.ByteWriter(value8, data_array, Start + (tree.SelectedNode.Index * Row) + column);
-                    Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + column, length);
+                    Byte.TryParse(GetText(textName), out byte value8);
+                    TitleForm.ByteWriter(value8, data_array, Start + (Tree.SelectedNode.Index * Row) + column);
+                    Array.Reverse(data_array, Start + (Tree.SelectedNode.Index * Row) + column, length);
                     break;
                 case MoveRequest.Load:
-                    Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + column, length);
-                    SetText(control, textName, this.data_array[Start + (tree.SelectedNode.Index * Row) + column].ToString("D"));
-                    Array.Reverse(data_array, Start + (tree.SelectedNode.Index * Row) + column, length);
+                    Array.Reverse(data_array, Start + (Tree.SelectedNode.Index * Row) + column, length);
+                    SetText(textName, this.data_array[Start + (Tree.SelectedNode.Index * Row) + column].ToString("D"));
+                    Array.Reverse(data_array, Start + (Tree.SelectedNode.Index * Row) + column, length);
                     break;
             }
         }
@@ -53,18 +57,18 @@
         //The following must be here, it was made by some guy on stackoverflow,  then modififed by starkelp in twitch chat :)
         //It takes things named TitleForm[X] where X is a variable with a string, and lets you use the string as a textboxes name with .text at the end.
         //This lets you use a variable in place of a textbox.text property, so you can refer to them indirectly.
-        public string GetText(Control.ControlCollection control, string name, string? defaultText = null) //this Form form, string name, string defaultText = null
+        public string GetText(string name, string? defaultText = null) //this Form form, string name, string defaultText = null
         {
-            return control.ContainsKey(name) ?
-                control[name].Text :
+            return Controls.ContainsKey(name) ?
+                Controls[name].Text :
                 (defaultText ?? string.Empty);
         }
 
-        public void SetText(Control.ControlCollection control, string name, string text) //this Form form, string name, string text
+        public void SetText(string name, string text) //this Form form, string name, string text
         {
-            if (control.ContainsKey(name))
+            if (Controls.ContainsKey(name))
             {
-                var control2 = control[name];
+                var control2 = Controls[name];
                 control2.Text = text;
             }
         }

--- a/Template/Enemy Template.cs
+++ b/Template/Enemy Template.cs
@@ -1,4 +1,6 @@
-﻿namespace Crystal_Editor
+﻿using static Crystal_Editor.CoreCommonEvent;
+
+namespace Crystal_Editor
 {
     public partial class EnemyTemplateForm : Form
     {
@@ -8,7 +10,7 @@
         public EnemyTemplateForm()
         {
             InitializeComponent();
-            events = new CoreCommonEvent(fileLocation: Properties.Settings.Default.SpotTemplateFolder + "\\Template Editor\\EnemyTemplate", start: 37, row: 38);
+            events = new CoreCommonEvent(fileLocation: Properties.Settings.Default.SpotTemplateFolder + "\\Template Editor\\EnemyTemplate", start: 37, row: 38, tree: Tree, controls: Controls);
 
             Tree.Nodes.Add("Goblin");
             Tree.Nodes.Add("Slime");
@@ -33,34 +35,31 @@
 
         private void Tree_AfterSelect(object sender, TreeViewEventArgs e)
         {
-            Editor(CoreCommonEvent.MoveRequest.Load);
+            Editor(MoveRequest.Load);
         }
         private void Button6_Click(object sender, EventArgs e) //Load Button
         {
-            Editor(CoreCommonEvent.MoveRequest.Load);
+            Editor(MoveRequest.Load);
         }
         private void Button5_Click(object sender, EventArgs e) //Save Button
         {
-            Editor(CoreCommonEvent.MoveRequest.Save);
+            Editor(MoveRequest.Save);
         }
 
-
-
-        public void Editor(CoreCommonEvent.MoveRequest requestType)
+        public void Editor(MoveRequest requestType)
         {
             //Numbers start from Left and read to right Right (normal?) Endianese.
             //Final number is the column the data is from / how many bytes into a row the data is from. The first byte is byte 1 not byte 0.
 
-            events.MoveData(Tree, Controls, textName: "richTextBoxID", column: 1, requestType); //1 Byte
-            events.MoveData(Tree, Controls, textName: "richTextBoxStr", column: 17, requestType); //4 Byte
-            events.MoveData(Tree, Controls, textName: "richTextBoxMag", column: 21, requestType); //4 Byte
-            events.MoveData(Tree, Controls, textName: "richTextBoxDef", column: 25, requestType); //2 Byte
-            events.MoveData(Tree, Controls, textName: "richTextBoxRes", column: 27, requestType); //2 Byte
-            events.MoveData(Tree, Controls, textName: "richTextBoxTP", column: 15, requestType); //1 Byte
+            events.MoveData(textName: "richTextBoxID", column: 1, requestType); //1 Byte
+            events.MoveData(textName: "richTextBoxStr", column: 17, requestType); //4 Byte
+            events.MoveData(textName: "richTextBoxMag", column: 21, requestType); //4 Byte
+            events.MoveData(textName: "richTextBoxDef", column: 25, requestType); //2 Byte
+            events.MoveData(textName: "richTextBoxRes", column: 27, requestType); //2 Byte
+            events.MoveData(textName: "richTextBoxTP", column: 15, requestType); //1 Byte
 
-            events.MoveDataReverse(Tree, Controls, textName: "richTextBoxRev4", column: 2, requestType, length: 4); //4R Byte
-            events.MoveDataReverse(Tree, Controls, textName: "richTextBoxRev2", column: 10, requestType, length: 2); //2R Byte
-
+            events.MoveDataReverse(textName: "richTextBoxRev4", column: 2, requestType, length: 4); //4R Byte
+            events.MoveDataReverse(textName: "richTextBoxRev2", column: 10, requestType, length: 2); //2R Byte
         }
 
         /*


### PR DESCRIPTION
Move Tree and Controls into the constructor, instead of requiring them to be passed into every single MoveData call.

Setup a static CoreCommonEvents using to simplify the MoveRequest calls.